### PR TITLE
Pyairtable 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyairtable
+pyairtable==2.3.6
 pandas
 numpy
 pydantic>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyairtable
 pandas
 numpy
+pydantic>=2.0


### PR DESCRIPTION
Rolled back to pyairtable 2.3.6 to stop the circular import error caused by version 3.0. 